### PR TITLE
Fix mta_sdk.php constructor

### DIFF
--- a/mta_sdk.php
+++ b/mta_sdk.php
@@ -211,7 +211,7 @@ class Element
 {
 	var $id;
 
-	function Element($id)
+	function __construct($id)
 	{
 		$this->id = $id;
 	}
@@ -228,7 +228,7 @@ class Resource
 	var $name;
 	private $server;
 
-	function Resource($name, $server)
+	function __construct($name, $server)
 	{
 		$this->name = $name;
 		$this->server = $server;


### PR DESCRIPTION
Resolves conflicts with PHP 7+ (Methods with the same name as their class will not be constructors in a future version of PHP)