### PR TITLE
Throw exception instead of getting a php warning

### DIFF
--- a/src/Exception/NotCallableResourceException.php
+++ b/src/Exception/NotCallableResourceException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*****************************************************************************
+ *
+ *  PROJECT:     MTA PHP SDK
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        NotCallableResourceException.php
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+declare(strict_types=1);
+
+namespace MultiTheftAuto\Sdk\Exception;
+
+class NotCallableResourceException extends MessageException
+{
+    protected const EXCEPTION_MESSAGE = 'There was a problem with the request. Ensure that the resource handling the call is running.';
+}

--- a/src/Transformer/ElementTransformer.php
+++ b/src/Transformer/ElementTransformer.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace MultiTheftAuto\Sdk\Transformer;
 
 use MultiTheftAuto\Sdk\Factory\ElementFactory;
+use MultiTheftAuto\Sdk\Exception\NotCallableResourceException;
 
 abstract class ElementTransformer
 {
@@ -29,8 +30,12 @@ abstract class ElementTransformer
 
         $data = json_decode($dataFromServer);
 
-        foreach ($data as &$value) {
-            ElementTransformer::stringValuesToObjects($value);
+        if ($data !== NULL) {
+            foreach ($data as &$value) {
+                ElementTransformer::stringValuesToObjects($value);
+            }
+        } else {
+            throw new NotCallableResourceException();
         }
 
         return $data;

--- a/src/Transformer/ElementTransformer.php
+++ b/src/Transformer/ElementTransformer.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace MultiTheftAuto\Sdk\Transformer;
 
-use MultiTheftAuto\Sdk\Factory\ElementFactory;
 use MultiTheftAuto\Sdk\Exception\NotCallableResourceException;
+use MultiTheftAuto\Sdk\Factory\ElementFactory;
 
 abstract class ElementTransformer
 {

--- a/src/Transformer/ElementTransformer.php
+++ b/src/Transformer/ElementTransformer.php
@@ -30,12 +30,12 @@ abstract class ElementTransformer
 
         $data = json_decode($dataFromServer);
 
-        if ($data !== NULL) {
-            foreach ($data as &$value) {
-                ElementTransformer::stringValuesToObjects($value);
-            }
-        } else {
-            throw new NotCallableResourceException();
+        if ($data === null) {
+            throw new NotCallableResourceException();   
+        }
+        
+        foreach ($data as &$value) {
+            ElementTransformer::stringValuesToObjects($value);
         }
 
         return $data;


### PR DESCRIPTION
When I accidentally tried to call a loaded, but not started resource on game server, I got a non-handleable invalid argument php warning inside the page body:
```
Warning: Invalid argument supplied for foreach() in vendor\multitheftauto\mtasa-php-sdk\src\Transformer\ElementTransformer.php on line 34
```

This will replace it with an exception which can be handled by code